### PR TITLE
pages.yml内に定義されているパッケージのバージョンを修正

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: "setup deno"
         uses: denoland/setup-deno@v1
         with:
@@ -38,12 +38,12 @@ jobs:
       - name: "build page"
         run: deno task build
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
お世話になっております。  
先ほどDejamuで作成したサイトをGithubActionsでデプロイしようとしたところ、  

>Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

とのエラーが出てデプロイが失敗しました。  
エラー文を元にバージョンを上げて再度試してみると上手く実行され、デプロイ速度も上がったので、ドラフトにて送付させていただきます。

---

### 参照パッケージ
https://github.com/actions/checkout  
https://github.com/actions/upload-pages-artifact  
https://github.com/actions/deploy-pages  
https://github.com/actions/configure-pages
